### PR TITLE
fix meta.mainProgram

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
           sha256 = meta.sha256;
         });
         version = meta.version;
+        meta.mainProgram = "code-insiders";
       });
     in
     {


### PR DESCRIPTION
When using lib.getExe on this package it will fail due to not having the meta.mainProgram defined.